### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/exosquare/ce37d42e-198b-4763-b660-a03358c2936a/bf39c4df-3fa2-4b05-99c2-82c5650c4266/_apis/work/boardbadge/daaf1c49-86cd-4675-98d2-ca78f5972058)](https://dev.azure.com/exosquare/ce37d42e-198b-4763-b660-a03358c2936a/_boards/board/t/bf39c4df-3fa2-4b05-99c2-82c5650c4266/Microsoft.RequirementCategory)
 # BpmCore
 BpmCore is a cross-platform, high performance, stateless, BPMN2.0 process engine for .NET


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/exosquare/ce37d42e-198b-4763-b660-a03358c2936a/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.